### PR TITLE
chore: clean up .gitignore by removing unnecessary comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# dependencies
+
 */node_modules
 /.pnp
 .pnp.js


### PR DESCRIPTION
The comment "# dependencies" was redundant as the entries below it are self-explanatory. Removing it improves the clarity and simplicity of the .gitignore file.